### PR TITLE
Add a custom parser to handle Sendgrid's 500 responses

### DIFF
--- a/lib/sendgrid_toolkit.rb
+++ b/lib/sendgrid_toolkit.rb
@@ -1,6 +1,7 @@
 require 'httparty'
 
 require 'sendgrid_toolkit/abstract_sendgrid_client'
+require 'sendgrid_toolkit/http_parser_party'
 require 'sendgrid_toolkit/common'
 require 'sendgrid_toolkit/sendgrid_error'
 require 'sendgrid_toolkit/statistics'

--- a/lib/sendgrid_toolkit/abstract_sendgrid_client.rb
+++ b/lib/sendgrid_toolkit/abstract_sendgrid_client.rb
@@ -13,7 +13,7 @@ module SendgridToolkit
 
     def api_post(module_name, action_name, opts = {})
       base_path = compose_base_path(module_name, action_name)
-      response = HTTParty.post("https://#{SendgridToolkit.base_uri}/#{base_path}.json",
+      response = HTTParserParty.post("https://#{SendgridToolkit.base_uri}/#{base_path}.json",
                                :body => get_credentials.merge(opts),
                                :format => :json)
       if response.code > 401

--- a/lib/sendgrid_toolkit/http_parser_party.rb
+++ b/lib/sendgrid_toolkit/http_parser_party.rb
@@ -1,0 +1,24 @@
+# Custom parser to deal with the sendgrid server returning HTML when JSON is requested.
+module SendgridToolkit
+  class HTTParserParty
+    include HTTParty
+
+    # Only support Atom
+    class Parser::OnlyJson < HTTParty::Parser
+      SupportedFormats = { "application/json" => :json }
+
+      protected
+
+      # perform atom parsing on body
+      def json
+        begin
+          super
+        rescue JSON::ParserError => e
+          return "#{body} - SendgridToolkit warning: We requested JSON, but the response generated the following error when we tried parsing it: #{e.class}: #{e}"
+        end
+      end
+    end
+
+    parser Parser::OnlyJson
+  end
+end

--- a/lib/sendgrid_toolkit/v3/abstract_sendgrid_client.rb
+++ b/lib/sendgrid_toolkit/v3/abstract_sendgrid_client.rb
@@ -15,20 +15,20 @@ module SendgridToolkit
       protected
 
       def api_post(action_name, options = {})
-        response = HTTParty.post("#{BASE_URI}/#{action_name}",
+        response = HTTParserParty.post("#{BASE_URI}/#{action_name}",
                                  body: options.to_json, format: :json,
                                  headers: { 'Authorization' => "Basic #{credentials}" })
         check_response(response)
       end
 
       def api_get(action_name, options = {})
-        response = HTTParty.get("#{BASE_URI}/#{action_name}",
+        response = HTTParserParty.get("#{BASE_URI}/#{action_name}",
                                 query: options, format: :json, headers: { 'Authorization' => "Basic #{credentials}" })
         check_response(response)
       end
 
       def api_delete(action_name, options = {})
-        response = HTTParty.delete("#{BASE_URI}/#{action_name}",
+        response = HTTParserParty.delete("#{BASE_URI}/#{action_name}",
                                    body: options, format: :json,
                                    headers: { 'Authorization' => "Basic #{credentials}" })
         check_response(response)

--- a/spec/lib/sendgrid_toolkit/abstract_sendgrid_client_spec.rb
+++ b/spec/lib/sendgrid_toolkit/abstract_sendgrid_client_spec.rb
@@ -23,6 +23,13 @@ describe SendgridToolkit::AbstractSendgridClient do
         @obj.send(:api_post, "profile", "get", {})
       }.should raise_error SendgridToolkit::SendgridServerError
     end
+    it "handles unexpected error responses gracefully" do
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/profile\.get\.json|, :body => '<html>Html formatted error</html>', :status => ['500', 'Internal Server Error'])
+      @obj = SendgridToolkit::AbstractSendgridClient.new("someuser", "somepass")
+      lambda {
+        @obj.send(:api_post, "profile", "get", {})
+      }.should raise_error SendgridToolkit::SendgridServerError, /<html>Html formatted error<\/html> - SendgridToolkit warning/
+    end
     it "thows error when sendgrid response is an API error" do
       FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/stats\.get\.json|, :body => '{"error": "error in end_date: end date is in the future"}', :status => ['400', 'Bad Request'])
       @obj = SendgridToolkit::AbstractSendgridClient.new("someuser", "somepass")

--- a/spec/lib/sendgrid_toolkit/v3/abstract_sendgrid_client_spec.rb
+++ b/spec/lib/sendgrid_toolkit/v3/abstract_sendgrid_client_spec.rb
@@ -23,6 +23,13 @@ describe SendgridToolkit::V3::AbstractSendgridClient do
         @obj.send(:api_post, "profile", "get", {})
       }.should raise_error SendgridToolkit::AuthenticationFailed
     end
+    it "handles unexpected error responses gracefully" do
+      FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI}/profile\.get\.json|, :body => '<html>Html formatted error</html>', :status => ['500', 'Internal Server Error'])
+      @obj = SendgridToolkit::AbstractSendgridClient.new("someuser", "somepass")
+      lambda {
+        @obj.send(:api_post, "profile", "get", {})
+      }.should raise_error SendgridToolkit::SendgridServerError, /<html>Html formatted error<\/html> - SendgridToolkit warning/
+    end
     it "thows error when sendgrid response is an API error" do
       FakeWeb.register_uri(:post, %r|https://#{REGEX_ESCAPED_BASE_URI_V3}/stats\.get\.json\?|, :body => '{"error": "error in end_date: end date is in the future"}', :status => ['400', 'Bad Request'])
       @obj = SendgridToolkit::AbstractSendgridClient.new("someuser", "somepass")


### PR DESCRIPTION
When Sendgrid returns a 502 they return it with a HTML error
page for the body, even though we requested application/json.
HTTParty will try to parse this response as JSON and then
throw a parsing error, which hides the real response that we
recieved from Sendgrid. This fix adds a custom parser which
catches the JSON:ParseError and falls back to returning
the body as it was given along with an error.

This is the recommended solution by HTTParty devs:
https://github.com/jnunemaker/httparty/issues/78#issuecomment-920787